### PR TITLE
Address issue #4: display list of organizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,11 @@
 
 
   <div class="container">
+        <div>
+            <ul id="orgs">
+            </ul>
+        </div>
+        <hr>
         <div id="repos" class="row">
 
         </div>

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ Modifications were made to include multiple organization accounts and display th
 
 (function () {
   /*
-  To add an organization to the portal edit orgs and orgNames below
+  To add an organization to the portal edit orgs and orgNameMap below
   For example in your github URL for your organization, the username follows right after: http://www.github.com/[user]
    */
   var orgs = ["sfgovdt","SFMOCI","sfcta","DataSF","OSVTAC"];
@@ -17,7 +17,7 @@ Modifications were made to include multiple organization accounts and display th
 
   Don't forget to mind your commas and colons (no comma after the last entry in the list)
    */
-  var orgNames = {
+  var orgNameMap = {
     sfmoci : "San Francisco Mayor's Office of Civic Innovation",
     sfcta : "San Francisco County Transportation Authority",
     sfgovdt : "San Francisco Department of Technology",
@@ -43,10 +43,7 @@ Modifications were made to include multiple organization accounts and display th
   var repoUrls = {
   };
 
-  function orgName(repo) {
-    return orgNames[repo.owner.login.toLowerCase()] || repo.name;
-  }
-
+  // Return the URL for an organization.
   function orgToUrl(org) {
     // First check for a non-GitHub URL.
     if (org in orgUrls) {
@@ -55,31 +52,33 @@ Modifications were made to include multiple organization accounts and display th
     return "https://github.com/" + org;
   }
 
-  function addOrg(org, fullName) {
-    var anchor = $("<a>").text(fullName);
+  // Add an organization to index.html.
+  function addOrg(org, orgName) {
+    var anchor = $("<a>").text(orgName);
     var url = orgToUrl(org);
     anchor.attr("href", url);
     var $item = $("<li>").append(anchor);
     $("#orgs").append($item);
   }
 
+  // Add all organizations to index.html.
   function addOrgs() {
-    // First, sort by name.
-    var fullNames = [];
-    var fullNameToOrg = {};
+    // First, sort the organizations by name.
+    var orgNames = [];
+    var orgNameToOrg = {};
     for (var i = 0; i < orgs.length; i++) {
       var org = orgs[i];
-      var fullName = orgNames[org.toLowerCase()];
-      fullNames.push(fullName);
-      fullNameToOrg[fullName] = org;
+      var orgName = orgNameMap[org.toLowerCase()];
+      orgNames.push(orgName);
+      orgNameToOrg[orgName] = org;
     }
-    fullNames.sort();
+    orgNames.sort();
 
     // Then add the organizations.
-    for (var i = 0; i < fullNames.length; i++) {
-      var fullName = fullNames[i];
-      var org = fullNameToOrg[fullName];
-      addOrg(org, fullName);
+    for (var i = 0; i < orgNames.length; i++) {
+      var orgName = orgNames[i];
+      var org = orgNameToOrg[orgName];
+      addOrg(org, orgName);
     }
   }
 
@@ -91,6 +90,10 @@ Modifications were made to include multiple organization accounts and display th
     return repoDescriptions[repo.name] || repo.description;
   }
 
+  function repoToOrgName(repo) {
+    return orgNameMap[repo.owner.login.toLowerCase()] || repo.name;
+  }
+
   function addRepo(repo) {
     var $item = $("<div>").addClass("col-sm-4 repo");
     var $link = $("<a>").attr("href", repoUrl(repo)).attr("id",repo.id).appendTo($item);
@@ -100,7 +103,7 @@ Modifications were made to include multiple organization accounts and display th
     $heading.append($("<small>").text(repo.language || ''));
     var $body = $("<div>").addClass("panel-body").appendTo($panel);
     $body.append($("<p>").text(repoDescription(repo)));
-    $panel.append($("<div>").addClass("panel-footer " + (repo.owner.login || '').toLowerCase()).text(orgName(repo)));
+    $panel.append($("<div>").addClass("panel-footer " + (repo.owner.login || '').toLowerCase()).text(repoToOrgName(repo)));
     $item.appendTo("#repos");
   }
 

--- a/main.js
+++ b/main.js
@@ -23,11 +23,16 @@ Modifications were made to include multiple organization accounts and display th
     sfgovdt : "San Francisco Department of Technology",
     datasf: "DataSF",
     osvtac: "San Francisco Open Source Voting System Technical Advisory Committee"
-  }
+  };
   /*
   That's it, you only need to edit above to add your organization
    */
 
+  // This stores custom organization URLs for those cases where the
+  // organization does not have a standard GitHub URL.
+  var orgUrls = {
+    sfgovdt: "https://bitbucket.org/sfgovdt/"
+  };
 
   function orgName(repo) {
     return orgNames[repo.owner.login.toLowerCase()] || repo.name;
@@ -45,6 +50,41 @@ Modifications were made to include multiple organization accounts and display th
     eas : "The Enterprise Addressing System (EAS) is an open source, web-based application that allows employees of government agencies to query, update, and retire street addresses.",
     CycleTracksWebsite : "Simple db and php code to catch data from iOS and Android CycleTracks apps."
   };
+
+  function orgToUrl(org) {
+    if (org in orgUrls) {
+      return orgUrls[org.toLowerCase()];
+    }
+    return "https://github.com/" + org;
+  }
+
+  function addOrg(org, fullName) {
+    var anchor = $("<a>").text(fullName);
+    var url = orgToUrl(org);
+    anchor.attr("href", url);
+    var $item = $("<li>").append(anchor);
+    $("#orgs").append($item);
+  }
+
+  function addOrgs() {
+    // First, sort by name.
+    var fullNames = [];
+    var fullNameToOrg = {};
+    for (var i = 0; i < orgs.length; i++) {
+      var org = orgs[i];
+      var fullName = orgNames[org.toLowerCase()];
+      fullNames.push(fullName);
+      fullNameToOrg[fullName] = org;
+    }
+    fullNames.sort();
+
+    // Then add the organizations.
+    for (var i = 0; i < fullNames.length; i++) {
+      var fullName = fullNames[i];
+      var org = fullNameToOrg[fullName];
+      addOrg(org, fullName);
+    }
+  }
 
   function repoDescription(repo) {
     return repoDescriptions[repo.name] || repo.description;
@@ -156,5 +196,6 @@ Modifications were made to include multiple organization accounts and display th
     });
   }
 
+  addOrgs();
   addRepos();
 })();

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ Modifications were made to include multiple organization accounts and display th
   To add an organization to the portal edit orgs and orgNames below
   For example in your github URL for your organization, the username follows right after: http://www.github.com/[user]
    */
-  var orgs = ["sfgovdt","sfmoci","sfcta","datasf","OSVTAC"];
+  var orgs = ["sfgovdt","SFMOCI","sfcta","DataSF","OSVTAC"];
 
   /*
   Put the full title of your department below, keyed by the github user

--- a/main.js
+++ b/main.js
@@ -34,24 +34,21 @@ Modifications were made to include multiple organization accounts and display th
     sfgovdt: "https://bitbucket.org/sfgovdt/"
   };
 
-  function orgName(repo) {
-    return orgNames[repo.owner.login.toLowerCase()] || repo.name;
-  }
-
-  var repoUrls = {
-  };
-
-  function repoUrl(repo) {
-    return repoUrls[repo.name] || repo.html_url;
-  }
-
   // Put custom repo descriptions in this object, keyed by repo name.
   var repoDescriptions = {
     eas : "The Enterprise Addressing System (EAS) is an open source, web-based application that allows employees of government agencies to query, update, and retire street addresses.",
     CycleTracksWebsite : "Simple db and php code to catch data from iOS and Android CycleTracks apps."
   };
 
+  var repoUrls = {
+  };
+
+  function orgName(repo) {
+    return orgNames[repo.owner.login.toLowerCase()] || repo.name;
+  }
+
   function orgToUrl(org) {
+    // First check for a non-GitHub URL.
     if (org in orgUrls) {
       return orgUrls[org.toLowerCase()];
     }
@@ -84,6 +81,10 @@ Modifications were made to include multiple organization accounts and display th
       var org = fullNameToOrg[fullName];
       addOrg(org, fullName);
     }
+  }
+
+  function repoUrl(repo) {
+    return repoUrls[repo.name] || repo.html_url;
   }
 
   function repoDescription(repo) {

--- a/main.js
+++ b/main.js
@@ -45,9 +45,10 @@ Modifications were made to include multiple organization accounts and display th
 
   // Return the URL for an organization.
   function orgToUrl(org) {
+    var orgLower = org.toLowerCase();
     // First check for a non-GitHub URL.
-    if (org in orgUrls) {
-      return orgUrls[org.toLowerCase()];
+    if (orgLower in orgUrls) {
+      return orgUrls[orgLower];
     }
     return "https://github.com/" + org;
   }


### PR DESCRIPTION
This addresses issue #4.

It adds an index listing of all participating organizations at the top, along with a link to their GitHub (or Bitbucket) page. Without this, it's hard to tell what all the organizations are.

A screenshot of what this PR looks like is attached below.

<img width="810" alt="screenshot" src="https://user-images.githubusercontent.com/355822/30303681-7b0213da-971e-11e7-88bb-58aa908394e9.png">
