### PR TITLE
Handle null descriptions.

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,6 +96,7 @@ Modifications were made to include multiple organization accounts and display th
   }
 
   function addRepo(repo) {
+    var description = repoDescription(repo);
     var $item = $("<div>").addClass("col-sm-4 repo");
     var $link = $("<a>").attr("href", repoUrl(repo)).attr("id",repo.id).appendTo($item);
     var $panel = $("<div>").addClass("panel panel-default " + (repo.language || '').toLowerCase()).appendTo($link);
@@ -103,7 +104,13 @@ Modifications were made to include multiple organization accounts and display th
     $heading.append($("<h3>").addClass("panel-title").text(repo.name));
     $heading.append($("<small>").text(repo.language || ''));
     var $body = $("<div>").addClass("panel-body").appendTo($panel);
-    $body.append($("<p>").text(repoDescription(repo)));
+    var $para = $("<p>");
+    if (description) {
+      $para.text(description);
+    } else {
+      $para.append($("<em>").text("No description provided."));
+    }
+    $body.append($para);
     $panel.append($("<div>").addClass("panel-footer " + (repo.owner.login || '').toLowerCase()).text(repoToOrgName(repo)));
     $item.appendTo("#repos");
   }


### PR DESCRIPTION
Currently, the site shows "null" for the description if the repo has no description. See attached screenshot below.

This PR makes it display something a bit more human-readable: _No description provided._

<img width="382" alt="screen shot 2017-09-13 at 8 00 35 am" src="https://user-images.githubusercontent.com/355822/30384791-19e1dce2-985a-11e7-8f30-57dfd903e294.png">
