### PR TITLE
Store source organization data in index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This is an minimal implementation of a portal for San Francisco's GitHub hosted 
 
 ### You already have a GitHub organizational account
 
-1. Go to [main.js](https://github.com/SFMOCI/sfmoci.github.io/blob/master/main.js) and click edit
-2. Use the web-based editor to add your GitHub organizational account name at the top of main.js
+1. Go to [`index.html`](https://github.com/SFMOCI/sfmoci.github.io/blob/master/index.html)
+   and click edit.
+2. Use the web-based editor to add your organization name and GitHub
+   (or Bitbucket) URL to the HTML list in the middle of the file.
 3. Below the editor window, there's a box to enter a required message, enter something like "Added organization SFO to the portal"
 4. Click Propose File Change at the bottom
 5. You can review changes on the next screen and to finish the edit, click the green button labeled "Send Pull Request"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is an minimal implementation of a portal for San Francisco's GitHub hosted 
 
 ### You already have a GitHub organizational account
 
-1. Go to [`index.html`](https://github.com/SFMOCI/sfmoci.github.io/blob/master/index.html)
+1. Go to [`index.html`](https://github.com/SFMOCI/sfmoci.github.io/blob/master/index.html#L72)
    and click edit.
 2. Use the web-based editor to add your organization name and GitHub
    (or Bitbucket) URL to the HTML list in the middle of the file.

--- a/index.html
+++ b/index.html
@@ -67,15 +67,26 @@
 
 
   <div class="container">
-        <div>
-            <ul id="orgs">
-            </ul>
-        </div>
-        <hr>
-        <div id="repos" class="row">
+    <div>
+      <!--
+      To add an organization to the portal, simply add an <li> element
+      below, following the pattern of the others.
 
-        </div>
-    </div><!-- /.container -->
+      The list should be alphabetized by organization name, and the URL
+      should be the GitHub or Bitbucket organization URL.  That's it!
+      -->
+      <ul id="orgs">
+        <li><a href="https://github.com/DataSF">DataSF</a></li>
+        <li><a href="https://github.com/sfcta">San Francisco County Transportation Authority</a></li>
+        <li><a href="https://bitbucket.org/sfgovdt/">San Francisco Department of Technology</a></li>
+        <li><a href="https://github.com/SFMOCI">San Francisco Mayor's Office of Civic Innovation</a></li>
+        <li><a href="https://github.com/OSVTAC">San Francisco Open Source Voting System Technical Advisory Committee</a></li>
+      </ul>
+    </div>
+    <hr>
+    <div id="repos" class="row">
+    </div>
+  </div><!-- /.container -->
 
 
   <!-- Modal -->

--- a/main.js
+++ b/main.js
@@ -5,34 +5,6 @@ Modifications were made to include multiple organization accounts and display th
  */
 
 (function () {
-  /*
-  To add an organization to the portal edit orgs and orgNameMap below
-  For example in your github URL for your organization, the username follows right after: http://www.github.com/[user]
-   */
-  var orgs = ["sfgovdt","SFMOCI","sfcta","DataSF","OSVTAC"];
-
-  /*
-  Put the full title of your department below, keyed by the github user
-  name you entered above, but normalized to lower-case.
-
-  Don't forget to mind your commas and colons (no comma after the last entry in the list)
-   */
-  var orgNameMap = {
-    sfmoci : "San Francisco Mayor's Office of Civic Innovation",
-    sfcta : "San Francisco County Transportation Authority",
-    sfgovdt : "San Francisco Department of Technology",
-    datasf: "DataSF",
-    osvtac: "San Francisco Open Source Voting System Technical Advisory Committee"
-  };
-  /*
-  That's it, you only need to edit above to add your organization
-   */
-
-  // This stores custom organization URLs for those cases where the
-  // organization does not have a standard GitHub URL.
-  var orgUrls = {
-    sfgovdt: "https://bitbucket.org/sfgovdt/"
-  };
 
   // Put custom repo descriptions in this object, keyed by repo name.
   var repoDescriptions = {
@@ -40,46 +12,40 @@ Modifications were made to include multiple organization accounts and display th
     CycleTracksWebsite : "Simple db and php code to catch data from iOS and Android CycleTracks apps."
   };
 
-  var repoUrls = {
-  };
+  // readOrgs() populates these three data structures from index.html.
+  // Putting the raw data in index.html is more SEO-friendly since the
+  // links are available in the original HTML as opposed to being
+  // "injected" by the javascript at render-time.
+  var orgs = [];
+  var orgNameMap = {};
+  var orgUrls = {};
 
-  // Return the URL for an organization.
-  function orgToUrl(org) {
-    var orgLower = org.toLowerCase();
-    // First check for a non-GitHub URL.
-    if (orgLower in orgUrls) {
-      return orgUrls[orgLower];
+  var repoUrls = {};
+
+  // Extract the organization username from the URL.
+  function urlToOrg(url) {
+    // Remove the trailing slash, if present.
+    if (url[url.length - 1] == "/") {
+      url = url.slice(0, -1);
     }
-    return "https://github.com/" + org;
+    var index = url.lastIndexOf("/") + 1;
+    var org = url.slice(index);
+
+    return org;
   }
 
-  // Add an organization to index.html.
-  function addOrg(org, orgName) {
-    var anchor = $("<a>").text(orgName);
-    var url = orgToUrl(org);
-    anchor.attr("href", url);
-    var $item = $("<li>").append(anchor);
-    $("#orgs").append($item);
-  }
+  // Read the organization data from index.html.
+  function readOrgs() {
+    var anchors = $("#orgs li a");
+    for (var i = 0; i < anchors.length; i++) {
+      var anchor = $(anchors[i]);
+      var orgName = anchor.text();
+      var url = anchor.attr("href");
+      var org = urlToOrg(url).toLowerCase();
 
-  // Add all organizations to index.html.
-  function addOrgs() {
-    // First, sort the organizations by name.
-    var orgNames = [];
-    var orgNameToOrg = {};
-    for (var i = 0; i < orgs.length; i++) {
-      var org = orgs[i];
-      var orgName = orgNameMap[org.toLowerCase()];
-      orgNames.push(orgName);
-      orgNameToOrg[orgName] = org;
-    }
-    orgNames.sort();
-
-    // Then add the organizations.
-    for (var i = 0; i < orgNames.length; i++) {
-      var orgName = orgNames[i];
-      var org = orgNameToOrg[orgName];
-      addOrg(org, orgName);
+      orgs.push(org);
+      orgNameMap[org] = orgName;
+      orgUrls[org] = url;
     }
   }
 
@@ -208,6 +174,6 @@ Modifications were made to include multiple organization accounts and display th
     });
   }
 
-  addOrgs();
+  readOrgs();
   addRepos();
 })();


### PR DESCRIPTION
This PR moves the "source" data for the list of organizations from `main.js` to `index.html`.  There are a few advantages to this.

The main advantage is for SEO / rendering reasons. The data is more accessible to crawlers and more readily available to users if the data is present in the first-served HTML, as oppposed to being injected at render-time via Javascript.

A few other reasons are:

* it simplifies the code (as evidenced by the amount of Javascript we can delete),
* it lets us control the style and structure of the list of orgs more easily (since we can just edit html),
* when it comes to adding new organizations, more people are familiar with editing HTML than Javascript, and
* the list of organizations will render even in the absence of Javascript.


I'm going to give this PR a few days before merging.