### PR TITLE
Simplify addRepos().

### DIFF
--- a/main.js
+++ b/main.js
@@ -149,24 +149,26 @@ Modifications were made to include multiple organization accounts and display th
     var urlPrefix = orgUrl.slice(0, 21);
     var bitbucket = (urlPrefix == "https://bitbucket.org");
 
-    if (!bitbucket) {
-      var uri = "https://api.github.com/orgs/" + org + "/repos?callback=?"
-          + "&per_page=100"
-          + "&page=" + page;
-    } else {
+    if (bitbucket) {
       var uri = "https://bitbucket.org/api/2.0/repositories/" + org + "?callback=?";
+    } else {
+      var uri = "https://api.github.com/orgs/" + org + "/repos?callback=?&per_page=100&page=" + page;
     }
 
     $.getJSON(uri, function (result) {
       if ((result.values && result.values.length > 0) || (result.data && result.data.length > 0)) {
+        var newRepos;
         if (bitbucket) {
           result = mapBitbucket(result);
-          repos = repos.concat(result.values);
-          addRepos(orgIdx + 1, repos);
+          newRepos = result.values;
+          orgIdx += 1;
+          page = 1;
         } else {
-          repos = repos.concat(result.data);
-          addRepos(orgIdx, repos, page + 1);
+          newRepos = result.data;
+          page += 1;
         }
+        repos = repos.concat(newRepos);
+        addRepos(orgIdx, repos, page);
       }
       else if (orgs.length > orgIdx + 1) {
         addRepos(orgIdx + 1, repos);

--- a/main.js
+++ b/main.js
@@ -142,14 +142,15 @@ Modifications were made to include multiple organization accounts and display th
   // Args:
   //   callback: a function that accepts an array of repos.
   function fetchOrgRepos(repos, org, callback, page) {
+    var uri;
     var orgUrl = orgUrls[org];
     var urlPrefix = orgUrl.slice(0, 21);
     var bitbucket = (urlPrefix == "https://bitbucket.org");
 
     if (bitbucket) {
-      var uri = "https://bitbucket.org/api/2.0/repositories/" + org + "?callback=?";
+      uri = "https://bitbucket.org/api/2.0/repositories/" + org + "?callback=?";
     } else {
-      var uri = "https://api.github.com/orgs/" + org + "/repos?callback=?&per_page=100&page=" + page;
+      uri = "https://api.github.com/orgs/" + org + "/repos?callback=?&per_page=100&page=" + page;
     }
 
     $.getJSON(uri, function (result) {
@@ -163,8 +164,7 @@ Modifications were made to include multiple organization accounts and display th
       }
       if (!bitbucket && newRepos.length >= 100) {
         // Then get the next page of results.
-        page += 1;
-        fetchOrgRepos(repos, org, callback, page);
+        fetchOrgRepos(repos, org, callback, page + 1);
       } else {
         callback(repos);
       }

--- a/main.js
+++ b/main.js
@@ -141,11 +141,9 @@ Modifications were made to include multiple organization accounts and display th
 
   // Args:
   //   callback: a function that accepts an array of repos.
-  function fetchOrgRepos(repos, org, callback, page) {
+  function fetchOrgRepos(repos, org, bitbucket, callback, page) {
+    page = page || 1;
     var uri;
-    var orgUrl = orgUrls[org];
-    var urlPrefix = orgUrl.slice(0, 21);
-    var bitbucket = (urlPrefix == "https://bitbucket.org");
 
     if (bitbucket) {
       uri = "https://bitbucket.org/api/2.0/repositories/" + org + "?callback=?";
@@ -164,7 +162,7 @@ Modifications were made to include multiple organization accounts and display th
       }
       if (!bitbucket && newRepos.length >= 100) {
         // Then get the next page of results.
-        fetchOrgRepos(repos, org, callback, page + 1);
+        fetchOrgRepos(repos, org, bitbucket, callback, page + 1);
       } else {
         callback(repos);
       }
@@ -178,12 +176,14 @@ Modifications were made to include multiple organization accounts and display th
       return;
     }
 
-    function callback(repos) {
-      addRepos(repos, orgIndex + 1);
-    }
-
     var org = orgs[orgIndex];
-    fetchOrgRepos(repos, org, callback, 1);
+    var orgUrl = orgUrls[org];
+    var urlPrefix = orgUrl.slice(0, 21);
+    var bitbucket = (urlPrefix == "https://bitbucket.org");
+
+    fetchOrgRepos(repos, org, bitbucket, function (repos) {
+      addRepos(repos, orgIndex + 1);
+    });
   }
 
   readOrgs();

--- a/main.js
+++ b/main.js
@@ -102,12 +102,14 @@ Modifications were made to include multiple organization accounts and display th
     page = page || 1;
     bitbucket = bitbucket || false;
 
+    var org = orgs[orgIdx];
+
     if (!bitbucket) {
-      var uri = "https://api.github.com/orgs/"+orgs[orgIdx]+"/repos?callback=?"
+      var uri = "https://api.github.com/orgs/" + org + "/repos?callback=?"
           + "&per_page=100"
           + "&page=" + page;
     } else {
-      var uri = "https://bitbucket.org/api/2.0/repositories/" + orgs[orgIdx] +"?callback=?";
+      var uri = "https://bitbucket.org/api/2.0/repositories/" + org + "?callback=?";
     }
 
     $.getJSON(uri, function (result) {

--- a/main.js
+++ b/main.js
@@ -96,13 +96,15 @@ Modifications were made to include multiple organization accounts and display th
     return result;
   }
 
-  function addRepos(orgIdx, repos, page, bitbucket) {
+  function addRepos(orgIdx, repos, page) {
     orgIdx = orgIdx || 0;
     repos = repos || [];
     page = page || 1;
-    bitbucket = bitbucket || false;
 
     var org = orgs[orgIdx];
+    var orgUrl = orgUrls[org];
+    var urlPrefix = orgUrl.slice(0, 21);
+    var bitbucket = (urlPrefix == "https://bitbucket.org");
 
     if (!bitbucket) {
       var uri = "https://api.github.com/orgs/" + org + "/repos?callback=?"
@@ -114,7 +116,7 @@ Modifications were made to include multiple organization accounts and display th
 
     $.getJSON(uri, function (result) {
       if ((result.values && result.values.length > 0) || (result.data && result.data.length > 0)) {
-        if(bitbucket) {
+        if (bitbucket) {
           result = mapBitbucket(result);
           repos = repos.concat(result.values);
           addRepos(orgIdx + 1, repos);
@@ -122,9 +124,6 @@ Modifications were made to include multiple organization accounts and display th
           repos = repos.concat(result.data);
           addRepos(orgIdx, repos, page + 1);
         }
-      }
-      else if (!bitbucket && result.data.message == "Not Found") {
-        addRepos(orgIdx, repos, 1, true);
       }
       else if (orgs.length > orgIdx + 1) {
         addRepos(orgIdx + 1, repos);


### PR DESCRIPTION
This PR breaks up and simplifies the `addRepos()` function.

It also cuts down the number of API requests needed to render the page by about half. It does this by looking to see if the number of results received equals the `per_page` value -- as opposed to paging until getting no results.

I will give this a few days before merging.
